### PR TITLE
Fix duration calculation in Rust template

### DIFF
--- a/tool/templates/template.rs
+++ b/tool/templates/template.rs
@@ -5,11 +5,7 @@ fn main() {
     let now = Instant::now();
     let output: String = run(args().nth(1).expect("Please provide an input"));
     let elapsed = now.elapsed();
-    println!(
-        "_duration:{}.{}",
-        elapsed.as_secs() * 1000 + u64::from(elapsed.subsec_millis()),
-        elapsed.subsec_micros() - (elapsed.subsec_millis() * 1000)
-    );
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
     println!("{}", output);
 }
 

--- a/tool/templates/template.rs
+++ b/tool/templates/template.rs
@@ -3,15 +3,15 @@ use std::time::Instant;
 
 fn main() {
     let now = Instant::now();
-    let output: String = run(args().nth(1).expect("Please provide an input"));
+    let output = run(&args().nth(1).expect("Please provide an input"));
     let elapsed = now.elapsed();
     println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
     println!("{}", output);
 }
 
-fn run(input: String) -> String {
+fn run(input: &str) -> isize {
     // Your code goes here
-    input
+    0
 }
 
 #[cfg(test)]
@@ -20,6 +20,6 @@ mod tests {
 
     #[test]
     fn run_test() {
-        assert_eq!(run("Test example".to_string()), "Test example".to_string())
+        assert_eq!(run("Test example"), 0)
     }
 }


### PR DESCRIPTION
When printing the run duration to stdout, the rust template displays the number of microseconds as an integer after the decimal point. This means there are no leading zeroes added:

```
let elapsed = Duration::from_micros(1); // Prints as 0.1
let elapsed = Duration::from_micros(100); // Prints as 0.100
```

Fixed by using the floating point representation directly.