### PR TITLE
Adds DEBUG_MODE for Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*_pyx_build
 .DS_Store
 .idea/
 node_modules/

--- a/day-02/part-1/bebert.pyx
+++ b/day-02/part-1/bebert.pyx
@@ -1,6 +1,6 @@
 cpdef int run(s):
     # s = "1,9,10,3,2,3,11,0,99,30,40,50"
-    cdef LEN_CODE = 200
+    cdef int LEN_CODE = 200
     cdef int[200] codes
     cdef int i
     cdef str x

--- a/day-02/part-2/bebert.pyx
+++ b/day-02/part-2/bebert.pyx
@@ -1,6 +1,6 @@
 cpdef int run(s):
     # s = "1,9,10,3,2,3,11,0,99,30,40,50"
-    cdef LEN_CODE = 200
+    cdef int LEN_CODE = 200
     cdef int[200] codes
     cdef int[200] init_state
     cdef int i, noun, verb

--- a/tool/runners/cython_aoc-setup.py
+++ b/tool/runners/cython_aoc-setup.py
@@ -1,21 +1,21 @@
+import os
 import sys
-from socket import gethostname
 
 from distutils.core import setup
 from Cython.Build import cythonize
 
+
+CYTHON_DEBUG = bool(os.getenv('CYTHON_DEBUG', ''))
+
 build_dir = sys.argv.pop()
 script_name = sys.argv.pop()
-
-quiet = gethostname() not in ["Aymeric-MBP.local"]
 
 setup(
     ext_modules=cythonize(
         script_name,
         build_dir=build_dir,
-        quiet=quiet,
+        quiet=not CYTHON_DEBUG,
+        annotate=CYTHON_DEBUG,
         compiler_directives={"language_level": 3},
     )
 )
-
-# annotate=True enables generation of the html annotation file

--- a/tool/runners/cython_aoc.py
+++ b/tool/runners/cython_aoc.py
@@ -8,6 +8,9 @@ from tool.runners.python import SubmissionPy
 from tool.runners.exceptions import RuntimeError
 
 
+CYTHON_DEBUG = bool(os.getenv('CYTHON_DEBUG', ''))
+
+
 class SubmissionPyx(SubmissionPy):
     def __init__(self, file):
         SubmissionPy.__init__(self)
@@ -61,6 +64,9 @@ class SubmissionPyx(SubmissionPy):
             raise RuntimeError(e)
 
     def cleanup(self):
+        if CYTHON_DEBUG:
+            print("Debug mode, keeping Cython build directory")
+            return
         try:
             shutil.rmtree(self.build_dir)
         except Exception as e:


### PR DESCRIPTION
Running with `CYTHON_DEBUG=1`
- generates cython/python GIL HTML report
- does not remove build directory