### PR TITLE
[tool] rename subprocess return code

### DIFF
--- a/tool/runners/rust.py
+++ b/tool/runners/rust.py
@@ -20,13 +20,13 @@ class SubmissionRs(SubmissionWrapper):
         except subprocess.CalledProcessError as e:
             raise CompilationError(e.output)
 
-        e = subprocess.Popen(
+        p = subprocess.Popen(
             ["cargo", "build", "--release", "--bin", file.replace("/", "-")[:-3]],
             env={**os.environ, "CARGO_TARGET_DIR": tmpdir.name},
             stdout=DEVNULL,
             stderr=DEVNULL,
         ).wait()
-        if e > 0:
+        if p > 0:
             raise CompilationError("Could not compile " + file)
         self.executable = tmpdir.name + "/release/" + file.replace("/", "-")[:-3]
 


### PR DESCRIPTION
Prevent variable name reuse

Proof of concept : 

```bash
$ python -m mypy day-01/part-2/badouralix.py
Tue Dec  3 22:31:23 CET 2019
tool/runners/rust.py:23: error: Assignment to variable 'e' outside except: block
Found 1 error in 1 file (checked 1 source file)
```

Reported in <https://github.com/python/mypy/issues/5080>