### PR TITLE
Filter out special chars in submission name

### DIFF
--- a/tool/create.py
+++ b/tool/create.py
@@ -44,9 +44,8 @@ def create_submission(author, path, language):
     # Extract submission template
     if language == "py":
         # Create a dedicated class with the author name
-        class_name = "".join(
-            x for x in f"{author} submission".title() if not x.isspace()
-        )
+        author_name = "".join(x if x.isalnum() else "_" for x in author)
+        class_name = "".join(x for x in f"{author} submission".title() if x.isalnum())
         submission_content = (
             open(os.path.join(TEMPLATES_PATH, "template.py"))
             .read()


### PR DESCRIPTION
This PR fixes the submission name when it contains special chars (eg `-`).